### PR TITLE
docs: clearify keys in meta object

### DIFF
--- a/content/pages/docs.md
+++ b/content/pages/docs.md
@@ -76,7 +76,7 @@ Property | Value | Example | Description
 -----|-----|-----|-----
 cards | array(object) |  | List of cards. (See Card table.)
 code | string | `"m19"` | Set code for the set.
-meta | object | `{"date": “2018-09-28","version": "4.0.0"}` | Keys are date or version. Date (OBDC standard) is date of build. Version is version of MTGJSON release.
+meta | object | `{"date": “2018-09-28","version": "4.0.0"}` | Keys are date and version. Date (OBDC standard) is date of build. Version is version of MTGJSON release.
 mtgoCode | string | `"m19"` | Set code for the set as it appears on Magic: The Gathering Online.
 releaseDate | string | `"2018-07-13"` | Date of release for the set.
 type | string | `"core"` | Type of set. Can be core, expansion, masters, masterpiece, from_the_vault, spellbook, premium_deck, duel_deck, draft_innovation, commander, planechase, archenemy, vanguard, funny, starter, box, promo, token or memorabilia.


### PR DESCRIPTION
Both keys are always present.